### PR TITLE
Remove quasi bootstrap

### DIFF
--- a/app/assets/stylesheets/default.css.erb
+++ b/app/assets/stylesheets/default.css.erb
@@ -57,20 +57,3 @@ a.btn-special:link, a.btn-special:visited {
 a.btn-special:hover, a.btn-special:active {
   background-color: green;
 }
-
-a.btn-danger:link, a.btn-danger:visited {
-  background-color: #f44336;
-  border-radius: 5px;
-  color: white;
-  padding: 14px 25px;
-  margin: 10px;
-  text-align: center;
-  text-decoration: none;
-  display: inline-block;
-  font-size: 16px;
-  font-family: "Times New Roman";
-}
-
-a.btn-danger:hover, a.btn-danger:active {
-  background-color: red;
-}

--- a/app/assets/stylesheets/default.css.erb
+++ b/app/assets/stylesheets/default.css.erb
@@ -24,23 +24,6 @@ input.btn-special:hover {
   background-color: green;
 }
 
-a.btn-default:link, a.btn-default:visited {
-  background-color: #3643fa;
-  border-radius: 5px;
-  color: white;
-  padding: 14px 25px;
-  margin: 10px;
-  text-align: center;
-  text-decoration: none;
-  display: inline-block;
-  font-size: 16px;
-  font-family: "Times New Roman";
-}
-
-a.btn-default:hover, a.btn-default:active {
-  background-color: blue;
-}
-
 a.btn-special:link, a.btn-special:visited {
   background-color: #4caf50;
   border-radius: 5px;

--- a/app/assets/stylesheets/default.css.erb
+++ b/app/assets/stylesheets/default.css.erb
@@ -5,38 +5,3 @@ header {
 table, th, td {
   border: 1px solid black;
 }
-
-input.btn-special {
-  background-color: #4caf50;
-  border: none;
-  border-radius: 5px;
-  color: white;
-  padding: 14px 25px;
-  margin: 10px;
-  text-align: center;
-  text-decoration: none;
-  display: inline-block;
-  font-size: 16px;
-  font-family: "Times New Roman";
-}
-
-input.btn-special:hover {
-  background-color: green;
-}
-
-a.btn-special:link, a.btn-special:visited {
-  background-color: #4caf50;
-  border-radius: 5px;
-  color: white;
-  padding: 14px 25px;
-  margin: 10px;
-  text-align: center;
-  text-decoration: none;
-  display: inline-block;
-  font-size: 16px;
-  font-family: "Times New Roman";
-}
-
-a.btn-special:hover, a.btn-special:active {
-  background-color: green;
-}

--- a/app/views/book_pages/edit.html.erb
+++ b/app/views/book_pages/edit.html.erb
@@ -5,7 +5,7 @@
   <%= f.label 'Order' %><br>
   <%= f.text_area :order %><br>
 
-  <%= f.submit "SUBMIT", :class => 'btn-special' %>
+  <%= f.submit "SUBMIT", :class => 'btn btn-primary' %>
 <% end %>
 <br />
 <a href="<%= book_book_page_path(@book, @book_page) %>" class="btn btn-info">CANCEL</a>

--- a/app/views/book_pages/edit.html.erb
+++ b/app/views/book_pages/edit.html.erb
@@ -8,4 +8,4 @@
   <%= f.submit "SUBMIT", :class => 'btn-special' %>
 <% end %>
 <br />
-<a href="<%= book_book_page_path(@book, @book_page) %>" class="btn-default">CANCEL</a>
+<a href="<%= book_book_page_path(@book, @book_page) %>" class="btn btn-info">CANCEL</a>

--- a/app/views/book_pages/index.html.erb
+++ b/app/views/book_pages/index.html.erb
@@ -1,7 +1,7 @@
 <h1>Pages for <%= @book.name %></h1>
 <a href="<%= book_path(@book) %>" class="btn btn-info">Back to <%= @book.name %></a>
 <br />
-<a href="<%= new_book_book_page_path(@book) %>" class="btn-special">New Page</a>
+<a href="<%= new_book_book_page_path(@book) %>" class="btn btn-secondary">New Page</a>
 <br />
 <br />
 <table>

--- a/app/views/book_pages/index.html.erb
+++ b/app/views/book_pages/index.html.erb
@@ -1,5 +1,5 @@
 <h1>Pages for <%= @book.name %></h1>
-<a href="<%= book_path(@book) %>" class="btn-default">Back to <%= @book.name %></a>
+<a href="<%= book_path(@book) %>" class="btn btn-info">Back to <%= @book.name %></a>
 <br />
 <a href="<%= new_book_book_page_path(@book) %>" class="btn-special">New Page</a>
 <br />
@@ -19,7 +19,7 @@
           <%= page.name %>
         </td>
         <td>
-          <a href="<%= book_book_page_path(@book, page) %>" class="btn-default">VIEW</a>
+          <a href="<%= book_book_page_path(@book, page) %>" class="btn btn-info">VIEW</a>
         </td>
       </tr>
     <% end %>

--- a/app/views/book_pages/new.html.erb
+++ b/app/views/book_pages/new.html.erb
@@ -8,4 +8,4 @@
   <%= f.submit "SUBMIT", :class => 'btn-special' %>
 <% end %>
 <br />
-<a href="<%= book_book_pages_path(@book) %>" class="btn-default">CANCEL</a>
+<a href="<%= book_book_pages_path(@book) %>" class="btn btn-info">CANCEL</a>

--- a/app/views/book_pages/new.html.erb
+++ b/app/views/book_pages/new.html.erb
@@ -5,7 +5,7 @@
   <%= f.label 'Order' %><br>
   <%= f.text_area :order %><br>
 
-  <%= f.submit "SUBMIT", :class => 'btn-special' %>
+  <%= f.submit "SUBMIT", :class => 'btn btn-primary' %>
 <% end %>
 <br />
 <a href="<%= book_book_pages_path(@book) %>" class="btn btn-info">CANCEL</a>

--- a/app/views/book_pages/show.html.erb
+++ b/app/views/book_pages/show.html.erb
@@ -11,4 +11,4 @@
 <%= link_to 'DELETE', book_book_page_path(@book_page, book_id: @book.id),
               method: :delete,
               data: { confirm: 'Are you sure?' },
-              class: "btn-danger" %>
+              class: "btn btn-danger" %>

--- a/app/views/book_pages/show.html.erb
+++ b/app/views/book_pages/show.html.erb
@@ -7,7 +7,7 @@
   <dd><%= @book_page.order %></dd>
 </dl>
 <br />
-<a href="<%= edit_book_book_page_path(@book_page, book_id: @book.id) %>" class="btn-special">EDIT</a>
+<a href="<%= edit_book_book_page_path(@book_page, book_id: @book.id) %>" class="btn btn-secondary">EDIT</a>
 <%= link_to 'DELETE', book_book_page_path(@book_page, book_id: @book.id),
               method: :delete,
               data: { confirm: 'Are you sure?' },

--- a/app/views/book_pages/show.html.erb
+++ b/app/views/book_pages/show.html.erb
@@ -1,6 +1,6 @@
 <h1><%= @book_page.name %></h1>
 <br />
-<a href="<%= book_book_pages_path(@book) %>" class="btn-default">Back to PAGES</a>
+<a href="<%= book_book_pages_path(@book) %>" class="btn btn-info">Back to PAGES</a>
 <br />
 <dl>
   <dt>ORDER</dt>

--- a/app/views/books/edit.html.erb
+++ b/app/views/books/edit.html.erb
@@ -8,4 +8,4 @@
   <%= f.submit "SUBMIT", :class => 'btn-special' %>
 <% end %>
 <br />
-<a href="<%= book_path(@book) %>" class="btn-default">CANCEL</a>
+<a href="<%= book_path(@book) %>" class="btn btn-info">CANCEL</a>

--- a/app/views/books/edit.html.erb
+++ b/app/views/books/edit.html.erb
@@ -5,7 +5,7 @@
   <%= f.label 'Description' %><br>
   <%= f.text_area :description %><br>
 
-  <%= f.submit "SUBMIT", :class => 'btn-special' %>
+  <%= f.submit "SUBMIT", :class => 'btn btn-primary' %>
 <% end %>
 <br />
 <a href="<%= book_path(@book) %>" class="btn btn-info">CANCEL</a>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -1,5 +1,5 @@
 <h1>Books</h1>
-<a href="<%= new_book_path() %>" class="btn-special">New Book</a>
+<a href="<%= new_book_path() %>" class="btn btn-secondary">New Book</a>
 <br />
 <br />
 <table>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -19,7 +19,7 @@
         </td>
         <td><%= book.description %></td>
         <td>
-          <a href="<%= book_path(book) %>" class="btn-default">VIEW</a>
+          <a href="<%= book_path(book) %>" class="btn btn-info">VIEW</a>
         </td>
       </tr>
     <% end %>

--- a/app/views/books/new.html.erb
+++ b/app/views/books/new.html.erb
@@ -5,7 +5,7 @@
   <%= f.label 'Description' %><br>
   <%= f.text_area :description %><br>
 
-  <%= f.submit "SUBMIT", :class => 'btn-special' %>
+  <%= f.submit "SUBMIT", :class => 'btn btn-primary' %>
 <% end %>
 <br />
 <a href="<%= books_path() %>" class="btn btn-info">CANCEL</a>

--- a/app/views/books/new.html.erb
+++ b/app/views/books/new.html.erb
@@ -8,4 +8,4 @@
   <%= f.submit "SUBMIT", :class => 'btn-special' %>
 <% end %>
 <br />
-<a href="<%= books_path() %>" class="btn-default">CANCEL</a>
+<a href="<%= books_path() %>" class="btn btn-info">CANCEL</a>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -8,7 +8,7 @@
 <%= link_to 'DELETE', book_path(@book),
               method: :delete,
               data: { confirm: 'Are you sure?' },
-              class: "btn-danger" %>
+              class: "btn btn-danger" %>
 <br />
 <a href="<%= book_book_pages_path(@book) %>" class="btn-default">PAGES</a>
 <br />

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -1,6 +1,6 @@
 <h1><%= @book.name %></h1>
 <br />
-<a href="<%= books_path() %>" class="btn-default">Back to BOOKS</a>
+<a href="<%= books_path() %>" class="btn btn-info">Back to BOOKS</a>
 <br />
 <%= @book.description %>
 <br />
@@ -10,9 +10,9 @@
               data: { confirm: 'Are you sure?' },
               class: "btn btn-danger" %>
 <br />
-<a href="<%= book_book_pages_path(@book) %>" class="btn-default">PAGES</a>
+<a href="<%= book_book_pages_path(@book) %>" class="btn btn-info">PAGES</a>
 <br />
-<a href="<%= book_layers_path(@book) %>" class="btn-default">LAYERS</a>
+<a href="<%= book_layers_path(@book) %>" class="btn btn-info">LAYERS</a>
 <hr />
 <ul class="nav nav-tabs" id="myTab" role="tablist">
   <li class="nav-item waves-effect waves-light">
@@ -40,7 +40,7 @@
     </ol>
   </div>
   <div class="tab-pane fade" id="output" role="tabpanel" aria-labelledby="output-tab">
-    <a href="<%= page_contents_book_path(@book, format: :js) %>" class="btn-default">DOWNLOAD LINK</a>
+    <a href="<%= page_contents_book_path(@book, format: :js) %>" class="btn btn-info">DOWNLOAD LINK</a>
     <br />
     <textarea readonly wrap="hard" rows="100" style="width:100%;">
     var current = 0;

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -4,7 +4,7 @@
 <br />
 <%= @book.description %>
 <br />
-<a href="<%= edit_book_path(@book) %>" class="btn-special">EDIT</a>
+<a href="<%= edit_book_path(@book) %>" class="btn btn-secondary">EDIT</a>
 <%= link_to 'DELETE', book_path(@book),
               method: :delete,
               data: { confirm: 'Are you sure?' },

--- a/app/views/layer_pages/edit.html.erb
+++ b/app/views/layer_pages/edit.html.erb
@@ -11,7 +11,7 @@
   <%= f.label 'Z-Index' %><br>
   <%= f.text_area :z_index %><br>
 
-  <%= f.submit "SUBMIT", :class => 'btn-special' %>
+  <%= f.submit "SUBMIT", :class => 'btn btn-primary' %>
 <% end %>
 <br />
 <a href="<%= book_layer_layer_page_path(@book, @layer, @layer_page) %>" class="btn btn-info">CANCEL</a>

--- a/app/views/layer_pages/edit.html.erb
+++ b/app/views/layer_pages/edit.html.erb
@@ -14,4 +14,4 @@
   <%= f.submit "SUBMIT", :class => 'btn-special' %>
 <% end %>
 <br />
-<a href="<%= book_layer_layer_page_path(@book, @layer, @layer_page) %>" class="btn-default">CANCEL</a>
+<a href="<%= book_layer_layer_page_path(@book, @layer, @layer_page) %>" class="btn btn-info">CANCEL</a>

--- a/app/views/layer_pages/index.html.erb
+++ b/app/views/layer_pages/index.html.erb
@@ -1,7 +1,7 @@
 <h1>Pages for <%= @book.name %></h1>
 <a href="<%= book_layer_path(@book, @layer) %>" class="btn btn-info">Back to <%= @layer.name %></a>
 <br />
-<a href="<%= new_book_layer_layer_page_path(@book, @layer) %>" class="btn-special">New Page</a>
+<a href="<%= new_book_layer_layer_page_path(@book, @layer) %>" class="btn btn-secondary">New Page</a>
 <br />
 <br />
 <table>

--- a/app/views/layer_pages/index.html.erb
+++ b/app/views/layer_pages/index.html.erb
@@ -1,5 +1,5 @@
 <h1>Pages for <%= @book.name %></h1>
-<a href="<%= book_layer_path(@book, @layer) %>" class="btn-default">Back to <%= @layer.name %></a>
+<a href="<%= book_layer_path(@book, @layer) %>" class="btn btn-info">Back to <%= @layer.name %></a>
 <br />
 <a href="<%= new_book_layer_layer_page_path(@book, @layer) %>" class="btn-special">New Page</a>
 <br />
@@ -19,7 +19,7 @@
           <%= page.name %>
         </td>
         <td>
-          <a href="<%= book_layer_layer_page_path(@book, @layer, page) %>" class="btn-default">VIEW</a>
+          <a href="<%= book_layer_layer_page_path(@book, @layer, page) %>" class="btn btn-info">VIEW</a>
         </td>
       </tr>
     <% end %>

--- a/app/views/layer_pages/new.html.erb
+++ b/app/views/layer_pages/new.html.erb
@@ -11,7 +11,7 @@
   <%= f.label 'z_index' %><br>
   <%= f.text_area :z_index %><br>
 
-  <%= f.submit "SUBMIT", :class => 'btn-special' %>
+  <%= f.submit "SUBMIT", :class => 'btn btn-primary' %>
 <% end %>
 <br />
 <a href="<%= book_layer_layer_pages_path(@book, @layer) %>" class="btn btn-info">CANCEL</a>

--- a/app/views/layer_pages/new.html.erb
+++ b/app/views/layer_pages/new.html.erb
@@ -14,4 +14,4 @@
   <%= f.submit "SUBMIT", :class => 'btn-special' %>
 <% end %>
 <br />
-<a href="<%= book_layer_layer_pages_path(@book, @layer) %>" class="btn-default">CANCEL</a>
+<a href="<%= book_layer_layer_pages_path(@book, @layer) %>" class="btn btn-info">CANCEL</a>

--- a/app/views/layer_pages/show.html.erb
+++ b/app/views/layer_pages/show.html.erb
@@ -19,4 +19,4 @@
 <%= link_to 'DELETE', book_layer_layer_page_path(@layer_page, book_id: @book.id, layer_id: @layer.id),
               method: :delete,
               data: { confirm: 'Are you sure?' },
-              class: "btn-danger" %>
+              class: "btn btn-danger" %>

--- a/app/views/layer_pages/show.html.erb
+++ b/app/views/layer_pages/show.html.erb
@@ -15,7 +15,7 @@
   <dd><%= @layer_page.z_index %></dd>
 </dl>
 <br />
-<a href="<%= edit_book_layer_layer_page_path(@layer_page, book_id: @book.id, layer_id: @layer.id) %>" class="btn-special">EDIT</a>
+<a href="<%= edit_book_layer_layer_page_path(@layer_page, book_id: @book.id, layer_id: @layer.id) %>" class="btn btn-secondary">EDIT</a>
 <%= link_to 'DELETE', book_layer_layer_page_path(@layer_page, book_id: @book.id, layer_id: @layer.id),
               method: :delete,
               data: { confirm: 'Are you sure?' },

--- a/app/views/layer_pages/show.html.erb
+++ b/app/views/layer_pages/show.html.erb
@@ -1,6 +1,6 @@
 <h1><%= @layer_page.name %></h1>
 <br />
-<a href="<%= book_layer_layer_pages_path(@book) %>" class="btn-default">Back to PAGES</a>
+<a href="<%= book_layer_layer_pages_path(@book) %>" class="btn btn-info">Back to PAGES</a>
 <br />
 <dl>
   <dt>SOURCE</dt>

--- a/app/views/layers/edit.html.erb
+++ b/app/views/layers/edit.html.erb
@@ -23,4 +23,4 @@
   <%= f.submit "SUBMIT", :class => 'btn-special' %>
 <% end %>
 <br />
-<a href="<%= book_layer_path(@book, @layer) %>" class="btn-default">CANCEL</a>
+<a href="<%= book_layer_path(@book, @layer) %>" class="btn btn-info">CANCEL</a>

--- a/app/views/layers/edit.html.erb
+++ b/app/views/layers/edit.html.erb
@@ -20,7 +20,7 @@
   <%= f.label 'Current' %><br>
   <%= f.text_area :current %><br>
 
-  <%= f.submit "SUBMIT", :class => 'btn-special' %>
+  <%= f.submit "SUBMIT", :class => 'btn btn-primary' %>
 <% end %>
 <br />
 <a href="<%= book_layer_path(@book, @layer) %>" class="btn btn-info">CANCEL</a>

--- a/app/views/layers/index.html.erb
+++ b/app/views/layers/index.html.erb
@@ -1,7 +1,7 @@
 <h1>Layers for <%= @book.name %></h1>
 <a href="<%= book_path(@book) %>" class="btn btn-info">Back to <%= @book.name %></a>
 <br />
-<a href="<%= new_book_layer_path(@book) %>" class="btn-special">New Layer</a>
+<a href="<%= new_book_layer_path(@book) %>" class="btn btn-secondary">New Layer</a>
 <br />
 <br />
 <table>

--- a/app/views/layers/index.html.erb
+++ b/app/views/layers/index.html.erb
@@ -1,5 +1,5 @@
 <h1>Layers for <%= @book.name %></h1>
-<a href="<%= book_path(@book) %>" class="btn-default">Back to <%= @book.name %></a>
+<a href="<%= book_path(@book) %>" class="btn btn-info">Back to <%= @book.name %></a>
 <br />
 <a href="<%= new_book_layer_path(@book) %>" class="btn-special">New Layer</a>
 <br />
@@ -23,7 +23,7 @@
           <%= layer.name %>
         </td>
         <td>
-          <a href="<%= book_layer_path(@book, layer) %>" class="btn-default">VIEW</a>
+          <a href="<%= book_layer_path(@book, layer) %>" class="btn btn-info">VIEW</a>
         </td>
       </tr>
     <% end %>

--- a/app/views/layers/new.html.erb
+++ b/app/views/layers/new.html.erb
@@ -23,4 +23,4 @@
   <%= f.submit "SUBMIT", :class => 'btn-special' %>
 <% end %>
 <br />
-<a href="<%= book_layers_path(@book) %>" class="btn-default">CANCEL</a>
+<a href="<%= book_layers_path(@book) %>" class="btn btn-info">CANCEL</a>

--- a/app/views/layers/new.html.erb
+++ b/app/views/layers/new.html.erb
@@ -20,7 +20,7 @@
   <%= f.label 'Current' %><br>
   <%= f.text_area :current %><br>
 
-  <%= f.submit "SUBMIT", :class => 'btn-special' %>
+  <%= f.submit "SUBMIT", :class => 'btn btn-primary' %>
 <% end %>
 <br />
 <a href="<%= book_layers_path(@book) %>" class="btn btn-info">CANCEL</a>

--- a/app/views/layers/show.html.erb
+++ b/app/views/layers/show.html.erb
@@ -37,6 +37,6 @@
 <%= link_to 'DELETE', book_layer_path(@layer, book_id: @book.id),
               method: :delete,
               data: { confirm: 'Are you sure?' },
-              class: "btn-danger" %>
+              class: "btn btn-danger" %>
 <br />
 <a href="<%= book_layer_layer_pages_path(@book,@layer) %>" class="btn-default">LAYER PAGES</a>

--- a/app/views/layers/show.html.erb
+++ b/app/views/layers/show.html.erb
@@ -1,6 +1,6 @@
 <h1><%= @layer.name %></h1>
 <br />
-<a href="<%= book_layers_path(@book) %>" class="btn-default">Back to LAYERS</a>
+<a href="<%= book_layers_path(@book) %>" class="btn btn-info">Back to LAYERS</a>
 <br />
 <dl>
   <dt>IID</dt>
@@ -10,7 +10,7 @@
   <dt>PAGE</dt>
   <dd>
     <% if @layer.page.present? %>
-      <a href="<%= @page_url %>" class="btn-default"><%= @layer.page.name %></a>
+      <a href="<%= @page_url %>" class="btn btn-info"><%= @layer.page.name %></a>
     <% else %>
       (none)
     <% end %>
@@ -39,4 +39,4 @@
               data: { confirm: 'Are you sure?' },
               class: "btn btn-danger" %>
 <br />
-<a href="<%= book_layer_layer_pages_path(@book,@layer) %>" class="btn-default">LAYER PAGES</a>
+<a href="<%= book_layer_layer_pages_path(@book,@layer) %>" class="btn btn-info">LAYER PAGES</a>

--- a/app/views/layers/show.html.erb
+++ b/app/views/layers/show.html.erb
@@ -33,7 +33,7 @@
   <dd><%= @layer.current %></dd>
 </dl>
 <br />
-<a href="<%= edit_book_layer_path(@layer, book_id: @book.id) %>" class="btn-special">EDIT</a>
+<a href="<%= edit_book_layer_path(@layer, book_id: @book.id) %>" class="btn btn-secondary">EDIT</a>
 <%= link_to 'DELETE', book_layer_path(@layer, book_id: @book.id),
               method: :delete,
               data: { confirm: 'Are you sure?' },

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,7 +12,7 @@
 
   <body>
     <header>
-      <%= link_to "HOME", root_path, class: "btn-special" %>
+      <%= link_to "HOME", root_path, class: "btn btn-light" %>
     </header>
     <%= yield %>
   </body>


### PR DESCRIPTION
Removed the quasi-bootstrap buttons and replaced with proper Bootstrap.

'btn-danger' replaced with it's Bootstrap styling of the same name.

'btn-default' replaced with 'btn-info'.

'btn-special' replaced with 3 different stylings: 'btn-primary' for form submission, 'btn-secondary' for links to forms, and 'btn-light' for header link.