### PR TITLE
Iid order scope

### DIFF
--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -10,7 +10,7 @@ class Book < ApplicationRecord
   end
 
   def layers_serialized_as_json
-    JSON.pretty_generate(Layer.serialized_as_json(layers.order(:iid)))
+    JSON.pretty_generate(Layer.serialized_as_json(layers.ordered_by_iid))
   end
 
   def pages_list_select_sorted

--- a/app/models/layer.rb
+++ b/app/models/layer.rb
@@ -8,6 +8,7 @@ class Layer < ApplicationRecord
   has_many :layer_pages
 
   default_scope { order(order: :asc) }
+  scope :ordered_by_iid, -> { reorder(iid: :asc) }
 
   CONTROLS = ['hidden','toggle','select']
 


### PR DESCRIPTION
Replaced order by iid call with new scope.

This is expected to be completely unnecessary as the ordering isn't planned to be used outside of the one method and was already self-explanatory, but implemented anyway as an exercise in creating scopes.